### PR TITLE
Remove egg_info

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
 [zopeskel]
 template = plone
 
-[egg_info]
-tag_build = dev
-tag_svn_revision = true
-


### PR DESCRIPTION
Setting plone.registry on development with this egg_info section in
setup.cfg made its version be 1.0.3.dev0dev-r0 which was breaking
setuptools ordering as can be seen in:
http://jenkins.plone.org/view/Dependencies/job/plone-package-dependencies/193/console

This drove me nuts for quite a lot of months until I had enough to investigate it.

I will do a quick check on all other distributions, but this ``[egg_info]`` section is evil evil evil.