### PR TITLE
Complex Records Proxy: class allowing IObject fields to be stored as separate records

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,13 +1,15 @@
 Changelog
 =========
 
-1.0.3 (unreleased)
+1.1 (unreleased)
 ------------------
 
 - Cleanup: Pep8, utf8 headers, whitespace fixes, readability, ReST-fixes,
   doc-style, etc.
   [jensens]
 
+- Add complexrecordsproxy for collective.complexrecordsproxy.
+  [tomgross]
 
 1.0.2 (2014-09-11)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changelog
   doc-style, etc.
   [jensens]
 
-- Add complexrecordsproxy for collective.complexrecordsproxy.
+- Add complexrecordsproxy from collective.complexrecordsproxy.
   [tomgross]
 
 1.0.2 (2014-09-11)

--- a/plone/registry/field.rst
+++ b/plone/registry/field.rst
@@ -885,3 +885,4 @@ Complex vocabularies or sources are not allowed::
     Traceback (most recent call last):
     ...
     TypeError: ('Could not adapt', <zope.schema._field.Choice object at ...>, <InterfaceClass plone.registry.interfaces.IPersistentField>)
+

--- a/plone/registry/recordsproxy.py
+++ b/plone/registry/recordsproxy.py
@@ -4,6 +4,7 @@ from UserDict import DictMixin
 from zope.interface import alsoProvides
 from zope.interface import implementer
 from zope.schema import getFieldsInOrder
+from zope.schema.interfaces import IObject, ICollection
 from zope.schema.interfaces import RequiredMissing
 import re
 
@@ -165,3 +166,73 @@ class RecordsProxyCollection(DictMixin):
         names = list(self.registry.records.keys(prefix+'.', prefix+'/'))
         for name in names:
             del self.registry.records[name]
+
+
+class ComplexRecordsProxy(RecordsProxy):
+
+    def __getattr__(self, name):
+        if name not in self.__schema__:
+            raise AttributeError(name)
+        field = self.__schema__.get(name)
+        if IObject.providedBy(field):
+            iface = field.schema
+            collection = self.__registry__.collectionOfInterface(
+                            iface,
+                            check=False,
+                            factory=ComplexRecordsProxy)
+            if collection.has_key(name):
+                value = collection[name]
+            else:
+                value = _marker
+        elif ICollection.providedBy(field) and \
+                IObject.providedBy(field.value_type):
+            iface = field.value_type.schema
+            coll_prefix = iface.__identifier__ + '.' + name
+            collection = self.__registry__.collectionOfInterface(
+                            iface,
+                            check=False,
+                            prefix=coll_prefix,
+                            factory=ComplexRecordsProxy)
+            value = collection.values()
+            if not value:
+                value = _marker
+        else:
+            value = self.__registry__.get(self.__prefix__ + name, _marker)
+        if value is _marker:
+            value = self.__schema__[name].missing_value
+        return value
+
+    def __setattr__(self, name, value):
+        if name in self.__schema__:
+            field = self.__schema__.get(name)
+            if IObject.providedBy(field):
+                iface = field.schema
+                collection = self.__registry__.collectionOfInterface(
+                                iface,
+                                check=False,
+                                factory=ComplexRecordsProxy)
+                collection[name] = value
+            elif ICollection.providedBy(field) and \
+                    IObject.providedBy(field.value_type):
+                iface = field.value_type.schema
+                # All tuple items are stored as records under
+                # the coll_prefix prefix:
+                coll_prefix = iface.__identifier__ + '.' + name
+                collection = self.__registry__.collectionOfInterface(
+                                iface,
+                                check=False,
+                                prefix=coll_prefix,
+                                factory=ComplexRecordsProxy)
+                # Clear collection before adding/updating in case of deletes.
+                collection.clear()
+                for idx, val in enumerate(value):
+                    # val is our obj created by the z3cform factory
+                    collection['r' + str(idx)] = val
+            else:
+                full_name = self.__prefix__ + name
+                if full_name not in self.__registry__:
+                    raise AttributeError(name)
+                self.__registry__[full_name] = value
+        else:
+            self.__dict__[name] = value
+

--- a/plone/registry/registry.rst
+++ b/plone/registry/registry.rst
@@ -437,6 +437,19 @@ And may be deleted::
     [<Record plone.registry.tests.IMailSettings/example.sender>,
      <Record plone.registry.tests.IMailSettings/example.smtp_host>]
 
+Complex Records
+---------------
+
+For storing complex elements in the registry there is a special 
+*ComplexRecordsProxy* factory. It allows storing objects providing IObject
+or even collections (ICollection) of objects and other entries in
+registries. It used like this ::
+
+    >>> from plone.registry.recordsproxy import ComplexRecordsProxy
+    >>> registry.forInterface(IMailPreferences, factory=ComplexRecordsProxy,
+    ...   check=False)
+    <ComplexRecordsProxy for plone.registry.tests.IMailPreferences>
+
 Using field references
 ======================
 


### PR DESCRIPTION
Add complexrecordsproxy from https://github.com/collective/collective.complexrecordsproxy to support objects in registry.

@sunew Are you ok with this? It is mostly your code.
