### PR TITLE
Improve performance of RecordsProxy.__iter__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Improve performance of RecordsProxy.__iter__ which is now invoked more in
+  core Plone as part of the requireJS configuration
+  [MatthewWilkes]
 
 
 1.1.2 (2016-12-06)

--- a/plone/registry/recordsproxy.py
+++ b/plone/registry/recordsproxy.py
@@ -115,7 +115,7 @@ class RecordsProxyCollection(DictMixin):
             if '.' not in name:
                 yield name
             else:
-                key = '.'.join(name.split('.')[:-1])
+                key = name.rsplit('.', 1)[0]
                 if key != last:
                     yield key
                     last = key


### PR DESCRIPTION
On a client site, we are seeing 18687 invocations of `RecordsProxy.__iter__` with an average total execution time of 0.254 seconds. With this patch, which avoids some splitting and rejoining to handle `.` characters, the average total execution time in this scenario is 0.131 seconds.