### PR TITLE
Bug: `Record.interface` no interfaceName

### DIFF
--- a/plone/registry/record.py
+++ b/plone/registry/record.py
@@ -102,7 +102,7 @@ class Record(Persistent):
     @property
     def interface(self):
         try:
-            return resolve(self.interfaceName)
+            return resolve(self.interfaceName) if self.interfaceName else None
         except ImportError:
             return None
 

--- a/plone/registry/tests.py
+++ b/plone/registry/tests.py
@@ -97,6 +97,29 @@ class TestBugs(unittest.TestCase):
         self.assertTrue(ICollection.providedBy(ref))
         self.assertTrue(IFieldRef.providedBy(ref))
 
+    def test_record_no_interface(self):
+        from plone.registry.registry import Registry
+        from plone.registry import field
+        from plone.registry.record import Record
+
+        registry = Registry()
+        f = field.TextLine(title="Foo")
+        registry.records["foo.bar"] = Record(f, "Bar")
+
+        self.assertIsNone(registry.records["foo.bar"].interfaceName)
+        self.assertIsNone(registry.records["foo.bar"].interface)
+
+    def test_record_interface(self):
+        from plone.registry.registry import Registry
+
+        registry = Registry()
+        registry.registerInterface(IMailSettings)
+        ifacename = IMailSettings.__identifier__
+        recordname = ifacename + '.sender'
+
+        self.assertEquals(registry.records[recordname].interfaceName, ifacename)
+        self.assertEquals(registry.records[recordname].interface, IMailSettings)
+
 
 class TestMigration(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
When `Record.interface` is used  on a record with no `interfaceName` it drops:

```
AttributeError: 'NoneType' object has no attribute 'split'
```

Provided test cases and fix.