### PR TITLE
Add per-request cache for registry value and proxy lookups

### DIFF
--- a/news/62.feature
+++ b/news/62.feature
@@ -1,0 +1,1 @@
+Add per-request cache for registry value and forInterface proxy lookups, avoiding repeated OOBTree traversals within a single request. [@jensens]

--- a/src/plone/registry/registry.py
+++ b/src/plone/registry/registry.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from BTrees.OOBTree import OOBTree
 from persistent import Persistent
 from plone.registry.events import RecordAddedEvent
@@ -13,12 +14,35 @@ from plone.registry.recordsproxy import RecordsProxy
 from plone.registry.recordsproxy import RecordsProxyCollection
 from zope.component import queryAdapter
 from zope.event import notify
+from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.schema import getFieldNames
 from zope.schema import getFieldsInOrder
 
 import re
 import warnings
+
+
+_CACHE_MARKER = object()
+
+
+def _get_request_cache(context):
+    """Return the per-request, per-registry value cache dict, or None."""
+    request = getRequest()
+    if request is None:
+        return None
+    try:
+        all_caches = request._plone_registry_cache
+    except AttributeError:
+        all_caches = {}
+        request._plone_registry_cache = all_caches
+    registry_id = id(aq_base(context))
+    try:
+        return all_caches[registry_id]
+    except KeyError:
+        cache = {}
+        all_caches[registry_id] = cache
+        return cache
 
 
 @implementer(IRegistry)
@@ -31,20 +55,40 @@ class Registry(Persistent):
     # Basic value access API
 
     def __getitem__(self, name):
-        # Fetch straight from records._values to avoid loading the field
-        # as a separate persistent object
-        return self.records._values[name]
+        cache = _get_request_cache(self)
+        if cache is not None:
+            value = cache.get(name, _CACHE_MARKER)
+            if value is not _CACHE_MARKER:
+                return value
+        value = self.records._values[name]
+        if cache is not None:
+            cache[name] = value
+        return value
 
     def get(self, name, default=None):
-        # Fetch straight from records._values to avoid loading the field
-        # as a separate persistent object
-        return self.records._values.get(name, default)
+        cache = _get_request_cache(self)
+        if cache is not None:
+            value = cache.get(name, _CACHE_MARKER)
+            if value is not _CACHE_MARKER:
+                return value
+        value = self.records._values.get(name, _CACHE_MARKER)
+        if value is _CACHE_MARKER:
+            return default
+        if cache is not None:
+            cache[name] = value
+        return value
 
     def __setitem__(self, name, value):
         # make sure we get the Record class' validation
         self.records[name].value = value
+        cache = _get_request_cache(self)
+        if cache is not None:
+            cache[name] = value
 
     def __contains__(self, name):
+        cache = _get_request_cache(self)
+        if cache is not None and name in cache:
+            return True
         return name in self.records._values
 
     # Records - make this a property so that it's readonly
@@ -65,6 +109,13 @@ class Registry(Persistent):
         if not prefix.endswith("."):
             prefix += "."
 
+        cache = _get_request_cache(self)
+        cache_key = ("__proxy__", interface.__identifier__, prefix, omit)
+        if cache is not None:
+            proxy = cache.get(cache_key)
+            if proxy is not None:
+                return proxy
+
         if check:
             for name in getFieldNames(interface):
                 if name not in omit and prefix + name not in self:
@@ -76,7 +127,12 @@ class Registry(Persistent):
         if factory is None:
             factory = RecordsProxy
 
-        return factory(self, interface, omitted=omit, prefix=prefix)
+        proxy = factory(self, interface, omitted=omit, prefix=prefix)
+
+        if cache is not None:
+            cache[cache_key] = proxy
+
+        return proxy
 
     def registerInterface(self, interface, omit=(), prefix=None):
         if prefix is None:
@@ -157,6 +213,11 @@ class _Records:
         self._fields = OOBTree()
         self._values = OOBTree()
 
+    def _invalidate_cache(self):
+        cache = _get_request_cache(self.__parent__)
+        if cache is not None:
+            cache.clear()
+
     def __setitem__(self, name, record):
         if not self._validkey(name):
             raise InvalidRegistryKey(record)
@@ -165,6 +226,7 @@ class _Records:
 
         self._setField(name, record.field)
         self._values[name] = record.value
+        self._invalidate_cache()
 
         record.__name__ = name
         record.__parent__ = self.__parent__
@@ -180,6 +242,7 @@ class _Records:
 
         del self._fields[name]
         del self._values[name]
+        self._invalidate_cache()
 
         notify(RecordRemovedEvent(record))
 
@@ -237,6 +300,7 @@ class _Records:
     def clear(self):
         self._fields.clear()
         self._values.clear()
+        self._invalidate_cache()
 
     # Helper methods
 

--- a/src/plone/registry/registry.py
+++ b/src/plone/registry/registry.py
@@ -27,18 +27,22 @@ _CACHE_MARKER = object()
 
 
 def _get_request_cache(context):
-    """Return the per-request, per-registry value cache dict, or None."""
+    """Return the per-request, per-registry value cache dict, or None.
+
+    Uses ``request.other`` directly (the dict Zope's HTTPRequest clears
+    at end-of-request).  Returns None when ``other`` is not available
+    (e.g. zope.publisher TestRequest or dict-based test stubs).
+    """
     request = getRequest()
     if request is None:
         return None
-    all_caches = request.get("_plone_registry_cache")
+    other = getattr(request, "other", None)
+    if other is None:
+        return None
+    all_caches = other.get("_plone_registry_cache")
     if all_caches is None:
         all_caches = {}
-        try:
-            request["_plone_registry_cache"] = all_caches
-        except TypeError:
-            # Request doesn't support item assignment (e.g. TestRequest)
-            return None
+        other["_plone_registry_cache"] = all_caches
     registry_id = id(aq_base(context))
     try:
         return all_caches[registry_id]

--- a/src/plone/registry/registry.py
+++ b/src/plone/registry/registry.py
@@ -31,11 +31,10 @@ def _get_request_cache(context):
     request = getRequest()
     if request is None:
         return None
-    try:
-        all_caches = request._plone_registry_cache
-    except AttributeError:
+    all_caches = request.get("_plone_registry_cache")
+    if all_caches is None:
         all_caches = {}
-        request._plone_registry_cache = all_caches
+        request["_plone_registry_cache"] = all_caches
     registry_id = id(aq_base(context))
     try:
         return all_caches[registry_id]

--- a/src/plone/registry/registry.py
+++ b/src/plone/registry/registry.py
@@ -34,7 +34,11 @@ def _get_request_cache(context):
     all_caches = request.get("_plone_registry_cache")
     if all_caches is None:
         all_caches = {}
-        request["_plone_registry_cache"] = all_caches
+        try:
+            request["_plone_registry_cache"] = all_caches
+        except TypeError:
+            # Request doesn't support item assignment (e.g. TestRequest)
+            return None
     registry_id = id(aq_base(context))
     try:
         return all_caches[registry_id]

--- a/src/plone/registry/tests.py
+++ b/src/plone/registry/tests.py
@@ -142,10 +142,27 @@ class TestMigration(unittest.TestCase):
 
 
 class FakeRequest:
-    """Minimal request-like object for testing request-level caching."""
+    """Minimal request-like object for testing request-level caching.
+
+    Uses a dict (``other``) for item access, mirroring Zope's
+    ``HTTPRequest.other`` which is cleared at end-of-request.
+    """
 
     def __init__(self):
         self.environ = {}
+        self.other = {}
+
+    def get(self, key, default=None):
+        return self.other.get(key, default)
+
+    def __getitem__(self, key):
+        return self.other[key]
+
+    def __setitem__(self, key, value):
+        self.other[key] = value
+
+    def __contains__(self, key):
+        return key in self.other
 
 
 class TestRequestValueCache(unittest.TestCase):
@@ -184,19 +201,19 @@ class TestRequestValueCache(unittest.TestCase):
         """Return the per-registry cache dict from the given request."""
         if request is None:
             request = self.request
-        all_caches = getattr(request, "_plone_registry_cache", {})
+        all_caches = request.get("_plone_registry_cache", {})
         return all_caches.get(id(self.registry), {})
 
     def _setCache(self, data):
         """Inject values into the per-registry cache on the request."""
-        self.request._plone_registry_cache = {id(self.registry): data}
+        self.request["_plone_registry_cache"] = {id(self.registry): data}
 
     # --- __getitem__ tests ---
 
     def test_getitem_no_request(self):
         """Without a request, values are fetched directly from OOBTree."""
         self.assertEqual(self.registry["test.key1"], "value1")
-        self.assertFalse(hasattr(self.request, "_plone_registry_cache"))
+        self.assertNotIn("_plone_registry_cache", self.request)
 
     def test_getitem_populates_cache(self):
         """First read with a request populates the cache."""
@@ -295,7 +312,7 @@ class TestRequestValueCache(unittest.TestCase):
 
         new_request = FakeRequest()
         setRequest(new_request)
-        self.assertFalse(hasattr(new_request, "_plone_registry_cache"))
+        self.assertNotIn("_plone_registry_cache", new_request)
 
         self.assertEqual(self.registry["test.key1"], "value1")
         self.assertIn("test.key1", self._getCache(new_request))
@@ -304,9 +321,9 @@ class TestRequestValueCache(unittest.TestCase):
     def test_cache_lazily_created(self):
         """Cache dict is only created on first registry access."""
         self._setRequest()
-        self.assertFalse(hasattr(self.request, "_plone_registry_cache"))
+        self.assertNotIn("_plone_registry_cache", self.request)
         self.registry["test.key1"]
-        self.assertTrue(hasattr(self.request, "_plone_registry_cache"))
+        self.assertIn("_plone_registry_cache", self.request)
 
     # --- __contains__ tests ---
 

--- a/src/plone/registry/tests.py
+++ b/src/plone/registry/tests.py
@@ -201,12 +201,12 @@ class TestRequestValueCache(unittest.TestCase):
         """Return the per-registry cache dict from the given request."""
         if request is None:
             request = self.request
-        all_caches = request.get("_plone_registry_cache", {})
+        all_caches = request.other.get("_plone_registry_cache", {})
         return all_caches.get(id(self.registry), {})
 
     def _setCache(self, data):
         """Inject values into the per-registry cache on the request."""
-        self.request["_plone_registry_cache"] = {id(self.registry): data}
+        self.request.other["_plone_registry_cache"] = {id(self.registry): data}
 
     # --- __getitem__ tests ---
 

--- a/src/plone/registry/tests.py
+++ b/src/plone/registry/tests.py
@@ -141,6 +141,285 @@ class TestMigration(unittest.TestCase):
         self.assertTrue(isinstance(registry._records, _Records))
 
 
+class FakeRequest:
+    """Minimal request-like object for testing request-level caching."""
+
+    def __init__(self):
+        self.environ = {}
+
+
+class TestRequestValueCache(unittest.TestCase):
+    """Tests for request-level value caching in Registry."""
+
+    def setUp(self):
+        setUp(self)
+        from plone.registry import field
+        from plone.registry.record import Record
+        from plone.registry.registry import Registry
+
+        self.registry = Registry()
+        self.registry.records["test.key1"] = Record(
+            field.TextLine(title="Key 1"), "value1"
+        )
+        self.registry.records["test.key2"] = Record(
+            field.TextLine(title="Key 2"), "value2"
+        )
+        self.registry.records["test.none"] = Record(
+            field.TextLine(title="None val", required=False), None
+        )
+        self.request = FakeRequest()
+
+    def tearDown(self):
+        from zope.globalrequest import clearRequest
+
+        clearRequest()
+        testing.tearDown(self)
+
+    def _setRequest(self):
+        from zope.globalrequest import setRequest
+
+        setRequest(self.request)
+
+    def _getCache(self, request=None):
+        """Return the per-registry cache dict from the given request."""
+        if request is None:
+            request = self.request
+        all_caches = getattr(request, "_plone_registry_cache", {})
+        return all_caches.get(id(self.registry), {})
+
+    def _setCache(self, data):
+        """Inject values into the per-registry cache on the request."""
+        self.request._plone_registry_cache = {id(self.registry): data}
+
+    # --- __getitem__ tests ---
+
+    def test_getitem_no_request(self):
+        """Without a request, values are fetched directly from OOBTree."""
+        self.assertEqual(self.registry["test.key1"], "value1")
+        self.assertFalse(hasattr(self.request, "_plone_registry_cache"))
+
+    def test_getitem_populates_cache(self):
+        """First read with a request populates the cache."""
+        self._setRequest()
+        self.assertEqual(self.registry["test.key1"], "value1")
+        cache = self._getCache()
+        self.assertIn("test.key1", cache)
+        self.assertEqual(cache["test.key1"], "value1")
+
+    def test_getitem_serves_from_cache(self):
+        """Subsequent reads return the cached value."""
+        self._setRequest()
+        self._setCache({"test.key1": "cached_value"})
+        self.assertEqual(self.registry["test.key1"], "cached_value")
+
+    def test_getitem_keyerror_not_cached(self):
+        """KeyError for missing keys propagates without caching."""
+        self._setRequest()
+        with self.assertRaises(KeyError):
+            self.registry["nonexistent.key"]
+        self.assertNotIn("nonexistent.key", self._getCache())
+
+    def test_getitem_multiple_keys(self):
+        """Multiple keys are independently cached."""
+        self._setRequest()
+        self.assertEqual(self.registry["test.key1"], "value1")
+        self.assertEqual(self.registry["test.key2"], "value2")
+        cache = self._getCache()
+        self.assertEqual(cache["test.key1"], "value1")
+        self.assertEqual(cache["test.key2"], "value2")
+
+    # --- get() tests ---
+
+    def test_get_no_request(self):
+        """Without a request, get() works normally."""
+        self.assertEqual(self.registry.get("test.key1"), "value1")
+        self.assertEqual(self.registry.get("nonexistent", "default"), "default")
+
+    def test_get_populates_cache(self):
+        """get() populates the cache on first access."""
+        self._setRequest()
+        self.assertEqual(self.registry.get("test.key1"), "value1")
+        self.assertIn("test.key1", self._getCache())
+
+    def test_get_serves_from_cache(self):
+        """get() returns cached value on subsequent access."""
+        self._setRequest()
+        self._setCache({"test.key1": "cached"})
+        self.assertEqual(self.registry.get("test.key1"), "cached")
+
+    def test_get_default_not_cached(self):
+        """get() with missing key returns default and does not cache it."""
+        self._setRequest()
+        result = self.registry.get("nonexistent", "default")
+        self.assertEqual(result, "default")
+        self.assertNotIn("nonexistent", self._getCache())
+
+    def test_get_none_value_cached(self):
+        """None values are correctly cached (not confused with sentinel)."""
+        self._setRequest()
+        result = self.registry.get("test.none")
+        self.assertIsNone(result)
+        self.assertIn("test.none", self._getCache())
+        self.assertIsNone(self.registry.get("test.none"))
+
+    def test_get_none_default(self):
+        """get() returns None default for missing keys without caching."""
+        self._setRequest()
+        result = self.registry.get("nonexistent")
+        self.assertIsNone(result)
+        self.assertNotIn("nonexistent", self._getCache())
+
+    # --- __setitem__ tests ---
+
+    def test_setitem_updates_cache(self):
+        """Writing a value updates the cache."""
+        self._setRequest()
+        self.assertEqual(self.registry["test.key1"], "value1")
+        self.registry["test.key1"] = "new_value"
+        self.assertEqual(self._getCache()["test.key1"], "new_value")
+        self.assertEqual(self.registry["test.key1"], "new_value")
+
+    def test_setitem_no_request(self):
+        """Writing without a request works normally."""
+        self.registry["test.key1"] = "new_value"
+        self.assertEqual(self.registry["test.key1"], "new_value")
+
+    # --- Cache isolation ---
+
+    def test_cache_isolation_between_requests(self):
+        """Different requests have independent caches."""
+        from zope.globalrequest import setRequest
+
+        self._setRequest()
+        self.registry["test.key1"]  # populate cache
+
+        new_request = FakeRequest()
+        setRequest(new_request)
+        self.assertFalse(hasattr(new_request, "_plone_registry_cache"))
+
+        self.assertEqual(self.registry["test.key1"], "value1")
+        self.assertIn("test.key1", self._getCache(new_request))
+        self.assertIn("test.key1", self._getCache(self.request))
+
+    def test_cache_lazily_created(self):
+        """Cache dict is only created on first registry access."""
+        self._setRequest()
+        self.assertFalse(hasattr(self.request, "_plone_registry_cache"))
+        self.registry["test.key1"]
+        self.assertTrue(hasattr(self.request, "_plone_registry_cache"))
+
+    # --- __contains__ tests ---
+
+    def test_contains_no_request(self):
+        """Without a request, __contains__ works normally."""
+        self.assertIn("test.key1", self.registry)
+        self.assertNotIn("nonexistent", self.registry)
+
+    def test_contains_uses_value_cache(self):
+        """__contains__ returns True if key is in the value cache."""
+        self._setRequest()
+        self.registry.get("test.key1")
+        self.assertIn("test.key1", self.registry)
+
+    def test_contains_falls_through_to_oobtree(self):
+        """__contains__ falls through to OOBTree for uncached keys."""
+        self._setRequest()
+        self.assertIn("test.key2", self.registry)
+        self.assertNotIn("nonexistent", self.registry)
+
+
+class TestForInterfaceCache(unittest.TestCase):
+    """Tests for forInterface() proxy caching."""
+
+    def setUp(self):
+        setUp(self)
+        from plone.registry.registry import Registry
+
+        self.registry = Registry()
+        self.registry.registerInterface(IMailSettings)
+        self.request = FakeRequest()
+
+    def tearDown(self):
+        from zope.globalrequest import clearRequest
+
+        clearRequest()
+        testing.tearDown(self)
+
+    def _setRequest(self):
+        from zope.globalrequest import setRequest
+
+        setRequest(self.request)
+
+    def test_forinterface_no_request(self):
+        """Without a request, forInterface works normally."""
+        proxy = self.registry.forInterface(IMailSettings)
+        self.assertTrue(IMailSettings.providedBy(proxy))
+
+    def test_forinterface_caches_proxy(self):
+        """With a request, forInterface caches the proxy."""
+        self._setRequest()
+        proxy1 = self.registry.forInterface(IMailSettings)
+        proxy2 = self.registry.forInterface(IMailSettings)
+        self.assertIs(proxy1, proxy2)
+
+    def test_forinterface_cache_hit_skips_check(self):
+        """Cached proxy avoids the field existence check."""
+        self._setRequest()
+        proxy1 = self.registry.forInterface(IMailSettings)
+        prefix = IMailSettings.__identifier__ + "."
+        key = prefix + "sender"
+        del self.registry.records._values[key]
+        del self.registry.records._fields[key]
+        proxy2 = self.registry.forInterface(IMailSettings)
+        self.assertIs(proxy1, proxy2)
+
+    def test_forinterface_same_prefix_different_interface_not_shared(self):
+        """Different interfaces with same prefix get separate proxies."""
+        self._setRequest()
+        proxy1 = self.registry.forInterface(
+            IMailSettings, check=False, prefix="shared.prefix"
+        )
+        proxy2 = self.registry.forInterface(
+            IMailPreferences, check=False, prefix="shared.prefix"
+        )
+        self.assertIsNot(proxy1, proxy2)
+        self.assertTrue(IMailSettings.providedBy(proxy1))
+        self.assertTrue(IMailPreferences.providedBy(proxy2))
+
+    def test_forinterface_different_prefix_not_shared(self):
+        """Different prefixes get separate cached proxies."""
+        self._setRequest()
+        self.registry.registerInterface(IMailSettings, prefix="alt.settings")
+        proxy1 = self.registry.forInterface(IMailSettings)
+        proxy2 = self.registry.forInterface(IMailSettings, prefix="alt.settings")
+        self.assertIsNot(proxy1, proxy2)
+
+    def test_forinterface_different_omit_not_shared(self):
+        """Different omit tuples get separate cached proxies."""
+        self._setRequest()
+        proxy1 = self.registry.forInterface(IMailSettings)
+        proxy2 = self.registry.forInterface(IMailSettings, omit=("sender",))
+        self.assertIsNot(proxy1, proxy2)
+
+    def test_forinterface_cache_isolation(self):
+        """Different requests have independent proxy caches."""
+        from zope.globalrequest import setRequest
+
+        self._setRequest()
+        proxy1 = self.registry.forInterface(IMailSettings)
+
+        new_request = FakeRequest()
+        setRequest(new_request)
+        proxy2 = self.registry.forInterface(IMailSettings)
+        self.assertIsNot(proxy1, proxy2)
+
+    def test_forinterface_no_request_returns_new_each_time(self):
+        """Without a request, each call returns a fresh proxy."""
+        proxy1 = self.registry.forInterface(IMailSettings)
+        proxy2 = self.registry.forInterface(IMailSettings)
+        self.assertIsNot(proxy1, proxy2)
+
+
 def test_suite():
     return unittest.TestSuite(
         [
@@ -170,5 +449,7 @@ def test_suite():
             ),
             unittest.defaultTestLoader.loadTestsFromTestCase(TestBugs),
             unittest.defaultTestLoader.loadTestsFromTestCase(TestMigration),
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestRequestValueCache),
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestForInterfaceCache),
         ]
     )


### PR DESCRIPTION
## Summary

- Cache registry value lookups (`__getitem__`, `get`, `__contains__`) in a per-request dict (`request._plone_registry_cache`), avoiding repeated OOBTree traversals for the same keys within a single request
- Cache `forInterface()` `RecordsProxy` objects per request, keyed by interface identifier + prefix + omit tuple
- Uses `zope.globalrequest.getRequest()` (thread-local, ~0.09 µs) to obtain the request

Caching is transparent: no request means no caching, same behavior as before. Cache lives on the request object and is discarded automatically at request end.

### RelStorage note

With RelStorage, OOBTree lookups are more expensive due to cache validation overhead and SQL round-trips on cache misses. Multi-process deployments (the main use case for RelStorage) also cause more frequent cache invalidations. The per-request caching bypasses ZODB entirely on repeated lookups, so savings with RelStorage will be larger than with FileStorage.

## Benchmark (interleaved, 30 rounds, vanilla Plone 6 site, FileStorage, Python 3.14)

| Scenario | Without cache | With cache | Saved |
|---|---|---|---|
| Single page (startpage) | 42.8 ms | 41.5 ms | +1.4 ms (+3.2%) |
| 4 diverse views | 177.1 ms | 173.9 ms | +3.2 ms (+1.8%) |
| 6 views incl. control panels | 265.3 ms | 258.3 ms | +7.0 ms (+2.7%) |

Gains grow with page complexity, number of add-ons, and number of registry lookups per request. These numbers are from a vanilla site with ~3000 registry records; production sites with more add-ons and RelStorage will see larger savings.