### PR TITLE
Invalidate request cache before firing RecordModifiedEvent

### DIFF
--- a/news/cache_invalidation.bugfix
+++ b/news/cache_invalidation.bugfix
@@ -1,0 +1,2 @@
+Invalidate the request cache for a record before firing the IRecordModifiedEvent to ensure subscribers see the new value.
+[erral]

--- a/src/plone/registry/record.py
+++ b/src/plone/registry/record.py
@@ -81,6 +81,8 @@ class Record(Persistent):
         self._value = value
 
         if self.__parent__ is not None:
+            if hasattr(self.__parent__.records, "_invalidate_key_cache"):
+                self.__parent__.records._invalidate_key_cache(self.__name__)
             self.__parent__.records._values[self.__name__] = value
 
         notify(RecordModifiedEvent(self, oldValue, value))

--- a/src/plone/registry/registry.py
+++ b/src/plone/registry/registry.py
@@ -224,6 +224,11 @@ class _Records:
         if cache is not None:
             cache.clear()
 
+    def _invalidate_key_cache(self, name):
+        cache = _get_request_cache(self.__parent__)
+        if cache is not None and name in cache:
+            del cache[name]
+
     def __setitem__(self, name, record):
         if not self._validkey(name):
             raise InvalidRegistryKey(record)

--- a/src/plone/registry/tests.py
+++ b/src/plone/registry/tests.py
@@ -207,6 +207,33 @@ class TestRequestValueCache(unittest.TestCase):
         """Inject values into the per-registry cache on the request."""
         self.request.other["_plone_registry_cache"] = {id(self.registry): data}
 
+    def test_subscriber_sees_new_value(self):
+        """A subscriber should see the new value even if the request cache exists."""
+        from plone.registry.interfaces import IRecordModifiedEvent
+        from zope.component import provideHandler
+
+        self._setRequest()
+
+        # Populate cache
+        self.assertEqual(self.registry["test.key1"], "value1")
+
+        seen_values = []
+
+        def subscriber(event):
+            # Try to read the value from the registry
+            seen_values.append(self.registry["test.key1"])
+
+        provideHandler(subscriber, (IRecordModifiedEvent,))
+
+        # Update value
+        self.registry["test.key1"] = "new_value"
+
+        self.assertEqual(
+            seen_values,
+            ["new_value"],
+            "Subscriber saw the old cached value instead of the new one",
+        )
+
     # --- __getitem__ tests ---
 
     def test_getitem_no_request(self):


### PR DESCRIPTION
When a record is modified, the registry fires the RecordModifiedEvent before updating or invalidating its internal per-request cache. This causes subscribers to see stale values if they read the record via the registry or a proxy. This PR invalidates the cache for the specific key right before the event notification.

This can be tested together with the following PR in plone.app.multilingual: https://github.com/plone/plone.app.multilingual/pull/544 

Fixes #69 and https://github.com/plone/plone.app.multilingual/issues/543